### PR TITLE
Make the connector compatible with the latest Identity Server

### DIFF
--- a/components/cas-inbound-authenticator/pom.xml
+++ b/components/cas-inbound-authenticator/pom.xml
@@ -126,7 +126,8 @@
                             org.eclipse.equinox.http.helper,
                             org.joda.time;version="${joda.wso2.osgi.version.range}",
 
-                            org.opensaml.saml.saml2.core.*,
+                            org.opensaml.saml.saml2.core,
+                            org.opensaml.saml.saml2.core.impl,
 
                             org.apache.xerces.util; resolution:=optional,
                             org.apache.http.*; version="${httpcomponents-httpclient.imp.pkg.version.range}",

--- a/components/cas-inbound-authenticator/pom.xml
+++ b/components/cas-inbound-authenticator/pom.xml
@@ -126,14 +126,9 @@
                             org.eclipse.equinox.http.helper,
                             org.joda.time;version="${joda.wso2.osgi.version.range}",
 
-                            org.opensaml.common,
-                            org.opensaml.saml2.core.*,
-                            org.opensaml.xml,
-                            org.opensaml.xml.util,
-                            org.opensaml.xml.validation,
+                            org.opensaml.saml.saml2.core.*,
 
                             org.apache.xerces.util; resolution:=optional,
-                            org.apache.xml.security.*; version="${wss4j.xml.security.imp.pkg.version.range}",
                             org.apache.http.*; version="${httpcomponents-httpclient.imp.pkg.version.range}",
 
                             org.apache.commons.codec.binary; version="${commons-codec.wso2.osgi.version.range}",

--- a/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/response/CASResponse.java
+++ b/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/response/CASResponse.java
@@ -18,8 +18,8 @@
 
 package org.wso2.carbon.identity.sso.cas.response;
 
-import org.opensaml.saml2.core.Response;
-import org.opensaml.saml2.core.impl.ResponseBuilder;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.impl.ResponseBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityMessageContext;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityResponse;
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>org.wso2.orbit.org.opensaml</groupId>
                 <artifactId>opensaml</artifactId>
-                <version>${opensaml2.wso2.version}</version>
+                <version>${opensaml3.wso2.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -213,14 +213,14 @@
         <carbon.identity.package.export.version>${project.version}</carbon.identity.package.export.version>
 
         <httpcore.version>4.3.3.wso2v1</httpcore.version>
-        <httpcomponents-httpclient.wso2.version>4.3.1.wso2v2</httpcomponents-httpclient.wso2.version>
+        <httpcomponents-httpclient.wso2.version>4.3.6.wso2v2</httpcomponents-httpclient.wso2.version>
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <axis2.wso2.version>1.6.1.wso2v12</axis2.wso2.version>
-        <opensaml2.wso2.version>2.6.4.wso2v5</opensaml2.wso2.version>
-        <joda.wso2.version>2.8.2.wso2v1</joda.wso2.version>
+        <opensaml3.wso2.version>3.3.1.wso2v2</opensaml3.wso2.version>
+        <joda.wso2.version>2.9.4.wso2v1</joda.wso2.version>
 
         <maven.scr.plugin.version>1.7.2</maven.scr.plugin.version>
-        <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
 
@@ -246,12 +246,11 @@
 
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
 
-        <opensaml.version>2.6.4</opensaml.version>
+        <opensaml.version>3.3.1</opensaml.version>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
         <axis2.osgi.version.range>[1.6.1.wso2v12, 2.0.0)</axis2.osgi.version.range>
-        <opensaml2.wso2.osgi.version.range>[2.6.0,3.0.0)</opensaml2.wso2.osgi.version.range>
+        <opensaml3.wso2.osgi.version.range>[3.3.1,3.4.0)</opensaml3.wso2.osgi.version.range>
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>
-        <wss4j.xml.security.imp.pkg.version.range>[1.4.2.patched,2.0.0)</wss4j.xml.security.imp.pkg.version.range>
         <httpcomponents-httpclient.imp.pkg.version.range>[4.3.1.wso2v2,5.0.0)
         </httpcomponents-httpclient.imp.pkg.version.range>
         <joda.wso2.osgi.version.range>[2.8.2,3.0.0)</joda.wso2.osgi.version.range>


### PR DESCRIPTION
## Purpose
- Make the CAS connector compatible with the latest Identity Server.
- Fixes: https://github.com/wso2/product-is/issues/12022

## Goals
- Provide support for OpenSAML3 instead of using OpenSAML2 so that the CAS connector can be used with the latest Identity Server without any unintended issues.

## Approach
- Upgrade OpenSAML2 related dependencies to OpenSAML3 and fix all the relevant implementation changes. Furthermore, some of the other dependencies were also upgraded to the latest version. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
- OS - Ubuntu 20.04.02
- JDK Version - JDK 8
- Identity Server Version - IS-5.11.0
 