### PR TITLE
Remove the dependency on the SAML2 library

### DIFF
--- a/components/cas-inbound-authenticator/pom.xml
+++ b/components/cas-inbound-authenticator/pom.xml
@@ -31,10 +31,6 @@
     <url>http://www.wso2.com</url>
     <dependencies>
         <dependency>
-            <groupId>org.wso2.orbit.org.opensaml</groupId>
-            <artifactId>opensaml</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.utils</artifactId>
         </dependency>
@@ -126,9 +122,6 @@
                             org.eclipse.equinox.http.helper,
                             org.joda.time;version="${joda.wso2.osgi.version.range}",
 
-                            org.opensaml.saml.saml2.core,
-                            org.opensaml.saml.saml2.core.impl,
-
                             org.apache.xerces.util; resolution:=optional,
                             org.apache.http.*; version="${httpcomponents-httpclient.imp.pkg.version.range}",
 
@@ -162,13 +155,9 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common;
                             version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.authenticator.saml2.sso.common;
-                            version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt;
-                            version="${carbon.identity.package.import.version.range}",
-                            org.wso2.carbon.identity.sso.saml.util;
                             version="${carbon.identity.package.import.version.range}",
                         </Import-Package>
                         <Export-Package>

--- a/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/processor/CASServiceValidationProcessor.java
+++ b/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/processor/CASServiceValidationProcessor.java
@@ -27,7 +27,6 @@ import org.wso2.carbon.identity.application.authentication.framework.inbound.Ide
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.sso.cas.context.CASMessageContext;
 import org.wso2.carbon.identity.sso.cas.request.CASServiceValidateRequest;
-import org.wso2.carbon.identity.sso.cas.response.CASResponse;
 import org.wso2.carbon.identity.sso.cas.response.CASServiceValidationResponse;
 
 import java.util.HashMap;
@@ -70,15 +69,15 @@ public class CASServiceValidationProcessor extends IdentityProcessor {
     }
 
     @Override
-    public CASResponse.CASResponseBuilder process(IdentityRequest identityRequest) throws FrameworkException {
+    public CASServiceValidationResponse.CASServiceValidationResponseBuilder process(IdentityRequest identityRequest) throws FrameworkException {
 
         CASMessageContext messageContext = new CASMessageContext((CASServiceValidateRequest) identityRequest, new
                 HashMap<String, String>());
         String redirectURL = messageContext.getServiceURL();
-        CASResponse.CASResponseBuilder builder = new CASServiceValidationResponse.CASServiceValidationResponseBuilder(
+        CASServiceValidationResponse.CASServiceValidationResponseBuilder builder = new CASServiceValidationResponse.CASServiceValidationResponseBuilder(
                 messageContext);
-        ((CASServiceValidationResponse.CASServiceValidationResponseBuilder) builder).buildResponse();
-        ((CASServiceValidationResponse.CASServiceValidationResponseBuilder) builder).setRedirectUrl(redirectURL);
+        builder.buildResponse();
+        builder.setRedirectUrl(redirectURL);
         return builder;
     }
 }

--- a/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/processor/SSOLoginProcessor.java
+++ b/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/processor/SSOLoginProcessor.java
@@ -18,10 +18,7 @@
 
 package org.wso2.carbon.identity.sso.cas.processor;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import javax.servlet.http.Cookie;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
@@ -34,7 +31,6 @@ import org.wso2.carbon.identity.sso.cas.configuration.CASConfiguration;
 import org.wso2.carbon.identity.sso.cas.context.CASMessageContext;
 import org.wso2.carbon.identity.sso.cas.request.CASSInitRequest;
 import org.wso2.carbon.identity.sso.cas.response.CASLoginResponse;
-import org.wso2.carbon.identity.sso.cas.response.CASResponse;
 import org.wso2.carbon.identity.sso.cas.ticket.ServiceTicket;
 import org.wso2.carbon.identity.sso.cas.ticket.TicketGrantingTicket;
 import org.wso2.carbon.identity.sso.cas.util.CASSSOUtil;
@@ -68,11 +64,11 @@ public class SSOLoginProcessor extends IdentityProcessor {
     }
 
     @Override
-    public CASResponse.CASResponseBuilder process(IdentityRequest identityRequest) throws FrameworkException {
+    public CASLoginResponse.CASLoginResponseBuilder process(IdentityRequest identityRequest) throws FrameworkException {
         Cookie casCookie = null;
         String serviceTicketId = null;
         CASMessageContext casMessageContext = (CASMessageContext) getContextIfAvailable(identityRequest);
-        CASResponse.CASResponseBuilder builder = new CASLoginResponse.CASLoginResponseBuilder(casMessageContext);
+        CASLoginResponse.CASLoginResponseBuilder builder = new CASLoginResponse.CASLoginResponseBuilder(casMessageContext);
         String serviceUrlFromRequest = casMessageContext.getServiceURL();
         AuthenticationResult authnResult = processResponseFromFrameworkLogin(casMessageContext, identityRequest);
         String acsURL = CASSSOUtil.getAcsUrl(serviceUrlFromRequest, casMessageContext.getRequest().getTenantDomain());
@@ -87,9 +83,9 @@ public class SSOLoginProcessor extends IdentityProcessor {
             ServiceTicket serviceTicket = ticketGrantingTicket.grantServiceTicket(acsURL);
             serviceTicketId = serviceTicket.getId();
         }
-        ((CASLoginResponse.CASLoginResponseBuilder) builder).setCasCookie(casCookie);
-        ((CASLoginResponse.CASLoginResponseBuilder) builder).setServiceTicketId(serviceTicketId);
-        ((CASLoginResponse.CASLoginResponseBuilder) builder).setRedirectUrl(serviceUrlFromRequest);
+        builder.setCasCookie(casCookie);
+        builder.setServiceTicketId(serviceTicketId);
+        builder.setRedirectUrl(serviceUrlFromRequest);
         return builder;
     }
 

--- a/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/response/CASResponse.java
+++ b/components/cas-inbound-authenticator/src/main/java/org/wso2/carbon/identity/sso/cas/response/CASResponse.java
@@ -18,37 +18,19 @@
 
 package org.wso2.carbon.identity.sso.cas.response;
 
-import org.opensaml.saml.saml2.core.Response;
-import org.opensaml.saml.saml2.core.impl.ResponseBuilder;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityMessageContext;
 import org.wso2.carbon.identity.application.authentication.framework.inbound.IdentityResponse;
 
 public class CASResponse extends IdentityResponse {
 
-    private Response response;
-
     protected CASResponse(IdentityResponseBuilder builder) {
         super(builder);
-        this.response = ((CASResponseBuilder) builder).response;
     }
 
-    public Response getResponse() {
-        return this.response;
-    }
-
-    public static class CASResponseBuilder extends IdentityResponseBuilder {
-
-        private Response response;
+    public static abstract class CASResponseBuilder extends IdentityResponseBuilder {
 
         public CASResponseBuilder(IdentityMessageContext context) {
             super(context);
-            ResponseBuilder responseBuilder = new ResponseBuilder();
-            this.response = responseBuilder.buildObject();
-        }
-
-        public CASResponseBuilder setResponse(Response response) {
-            this.response = response;
-            return this;
         }
     }
 }


### PR DESCRIPTION
## Purpose
Maybe I have overlooked something, but the dependency on SAML2 protocol/library seems to make no sense when implementing the CAS protocol in this module.

## Goals
Get rid of the dependency on the SAML2 library, simplifying the resulting module as a result.

## Approach
Just changing the code.

## User stories
The module won't successfully deploy to the WSO2 IS in the case there is the SAML2 module missing (which seems to be the case of IS 7.0.0 - although only with some older release of this library). This fix avoids this problem.

## Release note
Remove the dependency on the SAML2 library.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
* I'm still about to find out what URL/context this module maps to in order to expose the CAS endpoints. So I've only tested successful deployment and presence of the module in the UI for managing applications and their protocols.
* Tested against WSO2 IS 5.11.0 and 7.0.0.

## Learning
N/A